### PR TITLE
Configure rubocop 0.80.0 rules

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -113,3 +113,15 @@ Style/TrailingCommaInArrayLiteral:
 # Context-dependent
 Style/TrailingCommaInHashLiteral:
   Enabled: false
+
+# Context-dependent
+Style/HashEachMethods:
+  Enabled: false
+
+# Context-dependent
+Style/HashTransformKeys:
+  Enabled: false
+
+# Context-dependent
+Style/HashTransformValues:
+  Enabled: false

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -73,6 +73,10 @@ Naming/MethodParameterName:
 Performance/OpenStruct:
   Enabled: true
 
+#########################################################################
+# Pending Cops (To revisit the default value when rubocop 1.0 released) #
+#########################################################################
+
 Style/HashEachMethods:
   Enabled: true
 

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -73,6 +73,15 @@ Naming/MethodParameterName:
 Performance/OpenStruct:
   Enabled: true
 
+Style/HashEachMethods:
+  Enabled: true
+
+Style/HashTransformKeys:
+  Enabled: true
+
+Style/HashTransformValues:
+  Enabled: true
+
 #################
 # Disabled Cops #
 #################
@@ -112,16 +121,4 @@ Style/TrailingCommaInArrayLiteral:
 
 # Context-dependent
 Style/TrailingCommaInHashLiteral:
-  Enabled: false
-
-# Context-dependent
-Style/HashEachMethods:
-  Enabled: false
-
-# Context-dependent
-Style/HashTransformKeys:
-  Enabled: false
-
-# Context-dependent
-Style/HashTransformValues:
   Enabled: false


### PR DESCRIPTION
Since rubocop 0.80.0, all newly introduced cop rules can have `Enabled: pending` instead of default `Enabled: true/false`

Similar to https://github.com/rubocop-hq/rubocop/issues/7731

```sh
| => rubocop
The following cops were added to RuboCop, but are not configured. Please set Enabled to either `true` or `false` in your `.rubocop.yml` file:
 - Style/HashEachMethods (0.80)
 - Style/HashTransformKeys (0.80)
 - Style/HashTransformValues (0.80)
For more information: https://docs.rubocop.org/en/latest/versioning/
```

 - Style/HashEachMethods (0.80)
https://github.com/rubocop-hq/rubocop/blob/28f18aca4632307d6c490973adc6a72e16cc8cd8/config/default.yml#L2835

 - Style/HashTransformKeys (0.80)
https://github.com/rubocop-hq/rubocop/blob/28f18aca4632307d6c490973adc6a72e16cc8cd8/config/default.yml#L2871

 - Style/HashTransformValues (0.80)
https://github.com/rubocop-hq/rubocop/blob/28f18aca4632307d6c490973adc6a72e16cc8cd8/config/default.yml#L2865

Having warnings being output in the CLI seems to break sublime text linter add on. 

Not sure if other editors were affected.


