### PR TITLE
Assume that activejob error trace will still be inside log at least until Rails 6.1 release

### DIFF
--- a/lib/gecko-sane-defaults/core_ext/activejob.rb
+++ b/lib/gecko-sane-defaults/core_ext/activejob.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
-if ActiveJob::VERSION::STRING.in?(['5.2.4.1', '6.0.2.2', '6.0.3', '6.0.3.1'])
+active_job_version = Gem::Version.new(ActiveJob::VERSION::STRING)
+
+if active_job_version >= Gem::Version.new('5.2.4.1') && active_job_version < Gem::Version.new('6.1')
   # No need to log error backtraces, they're already sent to Honeybadger
   # See https://github.com/rails/rails/blob/master/activejob/lib/active_job/log_subscriber.rb
   module ActiveJobLogExt


### PR DESCRIPTION
So we don't need to update this at least till Rails 6.1 is release, then we can check whether this PR is included in the release https://github.com/rails/rails/pull/37994 