### PR TITLE
upgrade rubocop to 1.5.2 supported by hound

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,6 +1,6 @@
 rubocop:
   config_file: rubocop.yml
-  version: 0.80.0
+  version: 1.5.2
 
 jshint:
   enabled: false

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -4,6 +4,7 @@ require:
 
 AllCops:
   DisplayStyleGuide: true
+  NewCops: enable
   Exclude:
     - bin/**/*
     - db/schema.rb


### PR DESCRIPTION
http://help.houndci.com/en/articles/2461415-supported-linters

![image](https://user-images.githubusercontent.com/6453214/104671541-fc615180-5718-11eb-8e30-d3b3ff980ac8.png)
